### PR TITLE
Switching out to an EmployedGoblin type and fixing some bugs

### DIFF
--- a/Goblins.Core/EmployedGoblin.cs
+++ b/Goblins.Core/EmployedGoblin.cs
@@ -1,0 +1,8 @@
+﻿namespace Goblins.Core
+{
+    public record EmployedGoblin
+    {
+        public Goblin Goblin { get; init; } = new();
+        public string Job { get; set; } = string.Empty;
+    }
+}

--- a/Goblins.Core/Goblin.cs
+++ b/Goblins.Core/Goblin.cs
@@ -2,13 +2,11 @@
 
 namespace Goblins.Core
 {
-    public class Goblin
+    public record Goblin
     {
         public string? Name { get; set; }
         public Colour Colour { get; set; }
         public ITool[] Tools { get; set; } = Array.Empty<ITool>();
-        public string? Job { get; set; }
-
     }
 
     public enum Colour

--- a/Goblins.Core/GoblinEmploymentAgency.cs
+++ b/Goblins.Core/GoblinEmploymentAgency.cs
@@ -4,53 +4,69 @@ namespace Goblins.Core
 {
     public class GoblinEmploymentAgency
     {
-            public IEnumerable <Goblin> Employ (IEnumerable<Goblin> goblins) //Behavior version of employing
-            {
-                int stoppedGoblins = 0;
-                var miners = goblins
-                    .Where(goblin=> goblin.Colour==Colour.Red)
-                    .Where(goblin => goblin.Tools.OfType<Pickaxe>().Any())
-                    .Where(goblin => goblin.Tools.Count() == 1);
-
-                var writer = goblins
-                    .Where(goblin => goblin.Colour==Colour.Red)
-                    .Where(goblin => goblin.Tools.OfType<Pen>().Any())
-                    .Where(goblin => goblin.Tools.Count() == 1);
-
-                var rejects = goblins
-                    .Where(goblin => goblin.Colour==Colour.Blue || goblin.Tools.Count() > 1);
-
-                /*var towered = goblins
-                    .Except(miners)
-                    .Except(writer)
-                    .Except(rejects);*/
-                
-                
-                foreach (var goblin in goblins)
-                {
-                    if (miners.Contains(goblin)){
-                        goblin.Job = "Miner";
-                    }
-                    else if (writer.Contains(goblin)){
-                        goblin.Job = "Writer";
-                    }
-                    else if (rejects.Contains(goblin)){
-                        goblin.Job = "Rejected";
-                    }
-                    else {
-                        goblin.Job = "Tower";
-                        stoppedGoblins++;
-                    }
-                    
-                }
-
-                return goblins;
-            }
-
-        private Goblin GiveJob(Goblin goblin, string jobTitle)
+        public IEnumerable <EmployedGoblin> Employ (IEnumerable<Goblin> goblins) //Behavior version of employing
         {
-            goblin.Job = jobTitle;
-            return goblin;
+
+            var rejects = goblins
+                .Where(BlueGoblins)
+                .Union(goblins
+                    .Where(RedGoblins)
+                    .Where(WithTwoTools));
+
+            var miners = goblins
+                .Except(rejects)
+                .Where(RedGoblins)
+                .Where(WithPickaxes)
+                .Where(WithSingleTool);
+
+            var writer = goblins
+                .Except(rejects)
+                .Where(RedGoblins)
+                .Where(WithPens)
+                .Where(WithSingleTool);
+
+            var guards = goblins
+                .Except(rejects)
+                .Where(GreenGoblins)
+                .Union(goblins
+                    .Where(RedGoblins)
+                    .Where(WithNoTools));
+
+            return miners
+                .Select(g => EmployGoblin(g, "Miner"))
+                .Union(writer
+                    .Select(g => EmployGoblin(g, "Writer")))
+                .Union(guards
+                    .Select(g => EmployGoblin(g, "Tower")))
+                .Union(rejects
+                    .Select(g => EmployGoblin(g, "Rejected")));
         }
+
+        private static bool RedGoblins(Goblin goblin) => 
+            goblin.Colour == Colour.Red;
+
+        private static bool GreenGoblins(Goblin goblin) =>
+            goblin.Colour == Colour.Green;
+
+        private static bool BlueGoblins(Goblin goblin) =>
+            goblin.Colour == Colour.Blue;
+
+        private static bool WithPickaxes(Goblin goblin) =>
+            goblin.Tools.OfType<Pickaxe>().Any();
+
+        private static bool WithPens(Goblin goblin) =>
+            goblin.Tools.OfType<Pen>().Any();
+
+        private static bool WithSingleTool(Goblin goblin) =>
+            goblin.Tools.Count() == 1;
+
+        private static bool WithTwoTools(Goblin goblin) =>
+            goblin.Tools.Count() == 2;
+
+        private static bool WithNoTools(Goblin goblin) =>
+            !goblin.Tools.Any();
+
+        private static EmployedGoblin EmployGoblin(Goblin g, string job) => 
+            new EmployedGoblin() { Goblin = g, Job = job };
     }
 }

--- a/Goblins.Tests/IntegrationTests/WhenHatchingAndEmployingGoblins.cs
+++ b/Goblins.Tests/IntegrationTests/WhenHatchingAndEmployingGoblins.cs
@@ -6,7 +6,7 @@ namespace Goblins.Tests.IntegrationTests
 {
     public class WhenHatchingAndEmployingGoblins
     {
-        private IEnumerable<Goblin> employedGoblins = 
+        private IEnumerable<EmployedGoblin> employedGoblins = 
             new GoblinEmploymentAgency()
                     .Employ(new GoblinHatchery(
                         new TestGoblinDataProvider(
@@ -24,7 +24,7 @@ namespace Goblins.Tests.IntegrationTests
             .Should().AllSatisfy(goblin =>
             {
                 goblin.Job.Should().NotBeNullOrEmpty();
-                goblin.Name.Should().NotBeNullOrEmpty();
+                goblin.Goblin.Name.Should().NotBeNullOrEmpty();
 
             });
 
@@ -33,37 +33,52 @@ namespace Goblins.Tests.IntegrationTests
             employedGoblins
             .Should().BeEquivalentTo(new[]
             {
-                new Goblin()
+                new EmployedGoblin()
                 {
-                    Colour = Colour.Red,
-                    Tools = new[] { new Pen() },
+                    Goblin = new Goblin 
+                    {
+                        Colour = Colour.Red,
+                        Tools = new[] { new Pen() },
+                    },
                     Job = "Writer",
                 },
-                new Goblin()
+                new EmployedGoblin()
                 {
-                    Colour = Colour.Red,
-                    Tools = new[] { new Pickaxe() },
+                    Goblin = new Goblin
+                    {
+                        Colour = Colour.Red,
+                        Tools = new[] { new Pickaxe() },
+                    },
                     Job = "Miner",
                 },
-                new Goblin()
+                new EmployedGoblin()
                 {
-                    Colour = Colour.Blue,
-                    Tools = new[] { new Pen() },
+                    Goblin = new Goblin
+                    {
+                        Colour = Colour.Blue,
+                        Tools = new[] { new Pen() },
+                    },
                     Job = "Rejected",
                 },
-                new Goblin()
+                new EmployedGoblin()
                 {
-                    Colour = Colour.Green,
-                    Tools = Array.Empty<ITool>(),
+                    Goblin = new Goblin
+                    {
+                        Colour = Colour.Green,
+                        Tools = Array.Empty<ITool>(),
+                    },
                     Job = "Tower",
                 },
-                new Goblin()
+                new EmployedGoblin()
                 {
-                    Colour = Colour.Red,
-                    Tools = new ITool[] { new Pen(), new Pickaxe() },
+                    Goblin = new Goblin
+                    {
+                        Colour = Colour.Red,
+                        Tools = new ITool[] { new Pen(), new Pickaxe() },
+                    },
                     Job = "Rejected"
                 }
             }, 
-                options => options.Excluding(goblin => goblin.Name));
+            options => options.Excluding(goblin => goblin.Goblin.Name));
     }
 }

--- a/Goblins.Tests/UnitTests/WhenHatchingSingleGoblin.cs
+++ b/Goblins.Tests/UnitTests/WhenHatchingSingleGoblin.cs
@@ -20,9 +20,5 @@ namespace Goblins.Tests.UnitTests
         [Fact]
         public void ThenTheGoblinShouldHaveAName() =>
             goblins.Single().Name.Should().NotBeNullOrEmpty();
-
-        [Fact]
-        public void ThenTheGoblinShouldBeUnemployed() =>
-            goblins.Single().Job.Should().BeNullOrEmpty();
     }
 }

--- a/Goblins/Program.cs
+++ b/Goblins/Program.cs
@@ -10,9 +10,9 @@ var goblins = hatchery.Hatch();
 
 var employedGoblins = employmentAgency.Employ(goblins);
 
-foreach(var goblin in employedGoblins)
+foreach(var employedGoblin in employedGoblins)
 {
-    Console.WriteLine($"Goblin hatched! They are called {goblin.Name} and they are {goblin.Colour} and they weild a {goblin.Tools.First().GetType().Name} in their job as {goblin.Job}");
+    Console.WriteLine($"Goblin hatched! They are called {employedGoblin.Goblin.Name} and they are {employedGoblin.Goblin.Colour} and they weild a {employedGoblin.Goblin.Tools.First().GetType().Name} in their job as {employedGoblin.Job}");
 }
 
 //Given a set of freshly hatched goblins,


### PR DESCRIPTION


The root cause of the issue here is the bad specification that led us to having goblins that ended up being employed in 2 different ways (both "Reject" and "Tower" for red goblins with no tools) which then threw everything off, so i extended it out a bit to be super clear about what was going on and then it became clear that we needed to .Exclude() the goblins that were in the rejects list.

I then went a few steps further and tried to make the code as easy to read as i can, encoding the rules in methods like this, I'm not sure if I'm 100% in love with it, but it does read easier, what do you think?
